### PR TITLE
Update README.md

### DIFF
--- a/eagle/6502_board/README.md
+++ b/eagle/6502_board/README.md
@@ -2,7 +2,7 @@
 <p>
 These are the EAGLE files for the RC2014 6502 CPU Board.
 <p>
-Connect JP1 if you are using the Western Design Center 65C02 chip. This is the the VPB line.
+Connect JP1 if you aren't using the Western Design Center 65C02 chip. This is the VPB output on the WDC chip, but on other 65(C)02 chips this has to be connected to GND.
 <p>The A15 line selects the inverted A15 signal from the 6502. This allows you to use the standard RC2014 memory and I/O boards by inverting the 2 halves of the memory space: ROM sits at top of memory and RAM at the bottom of memory.
 <p>
 The I/O space is decoded by the 74HCT688 and is mapped as a 256-byte block to the start of 0C000H. You will map the Z80 I/O addresses to the 6502 I/O space by adding 0C000H.


### PR DESCRIPTION
Fixed a mistake in the ReadMe: JP1 should be shorted to GND when NOT using the WDC chip. On the WDC chip, VPB (Vector Pull (Bar)) is an output that should be disconnected.